### PR TITLE
Sample parser file

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,14 @@ $ lrama --version
 ## Usage
 
 ```shell
-# "y.tab.c" is generated
-$ lrama parse.y
+# "y.tab.c" and "y.tab.h" are generated
+$ lrama -d sample/parse.y
 ```
+
+## Build Ruby
+
+1. Install Lrama
+2. Run `make YACC=lrama`
 
 ## License
 

--- a/lib/lrama/output.rb
+++ b/lib/lrama/output.rb
@@ -205,6 +205,15 @@ module Lrama
       end
     end
 
+    # b4_user_args
+    def user_args
+      if @grammar.parse_param
+        ", #{parse_param_name}"
+      else
+        ""
+      end
+    end
+
     def extract_param_name(param)
       /\A(.)+([a-zA-Z0-9_]+)\z/.match(param)[2]
     end

--- a/lib/lrama/output.rb
+++ b/lib/lrama/output.rb
@@ -194,6 +194,28 @@ module Lrama
       end
     end
 
+    def parse_param_name
+      if @grammar.parse_param
+        /\A(.)+([a-zA-Z0-9_]+)\z/.match(parse_param)[2]
+      else
+        ""
+      end
+    end
+
+    # b4_parse_param_use
+    def parse_param_use(val, loc)
+      str = <<-STR
+  YY_USE (#{val});
+  YY_USE (#{loc});
+      STR
+
+      if @grammar.parse_param
+        str << "  YY_USE (#{parse_param_name});"
+      end
+
+      str
+    end
+
     # b4_table_value_equals
     def table_value_equals(table, value, literal, symbol)
       if literal < table.min || table.max < literal

--- a/lib/lrama/output.rb
+++ b/lib/lrama/output.rb
@@ -135,6 +135,17 @@ module Lrama
       str
     end
 
+    # b4_user_initial_action
+    def user_initial_action(comment = "")
+      return "" unless @grammar.initial_action
+
+      <<-STR
+        #{comment}
+        #line #{@grammar.initial_action.line} "#{@grammar_file_path}"
+        #{@grammar.initial_action.translated_code}
+      STR
+    end
+
     # b4_user_actions
     def user_actions
       str = ""

--- a/lib/lrama/output.rb
+++ b/lib/lrama/output.rb
@@ -259,6 +259,17 @@ module Lrama
       end
     end
 
+    # b4_yyerror_args
+    def yyerror_args
+      ary = ["&yylloc"]
+
+      if @grammar.parse_param
+        ary << parse_param_name
+      end
+
+      "#{ary.join(', ')}"
+    end
+
     def template_basename
       File.basename(template_file)
     end

--- a/lib/lrama/output.rb
+++ b/lib/lrama/output.rb
@@ -166,8 +166,12 @@ module Lrama
 
     # b4_parse_param
     def parse_param
-      # Omit "{}"
-      @grammar.parse_param[1..-2]
+      if @grammar.parse_param
+        # Omit "{}"
+        @grammar.parse_param[1..-2]
+      else
+        ""
+      end
     end
 
     # b4_user_formals

--- a/lib/lrama/output.rb
+++ b/lib/lrama/output.rb
@@ -175,11 +175,22 @@ module Lrama
       str
     end
 
+    def omit_braces(param)
+      param[1..-2]
+    end
+
     # b4_parse_param
     def parse_param
       if @grammar.parse_param
-        # Omit "{}"
-        @grammar.parse_param[1..-2]
+        omit_braces(@grammar.parse_param)
+      else
+        ""
+      end
+    end
+
+    def lex_param
+      if @grammar.lex_param
+        omit_braces(@grammar.lex_param)
       else
         ""
       end
@@ -194,9 +205,21 @@ module Lrama
       end
     end
 
+    def extract_param_name(param)
+      /\A(.)+([a-zA-Z0-9_]+)\z/.match(param)[2]
+    end
+
     def parse_param_name
       if @grammar.parse_param
-        /\A(.)+([a-zA-Z0-9_]+)\z/.match(parse_param)[2]
+        extract_param_name(parse_param)
+      else
+        ""
+      end
+    end
+
+    def lex_param_name
+      if @grammar.lex_param
+        extract_param_name(lex_param)
       else
         ""
       end
@@ -214,6 +237,17 @@ module Lrama
       end
 
       str
+    end
+
+    # b4_yylex_formals
+    def yylex_formals
+      ary = ["&yylval", "&yylloc"]
+
+      if @grammar.lex_param
+        ary << lex_param_name
+      end
+
+      "(#{ary.join(', ')})"
     end
 
     # b4_table_value_equals

--- a/sample/parse.y
+++ b/sample/parse.y
@@ -1,0 +1,58 @@
+/*
+ * This is comment for this file.
+ */
+
+%{
+// Prologue
+
+#include "y.tab.h"
+
+static enum yytokentype yylex(YYSTYPE *lval, YYLTYPE *yylloc);
+static void yyerror(YYLTYPE *yylloc, const char *msg);
+
+%}
+
+%expect 0
+%define api.pure
+%define parse.error verbose
+
+%union {
+    int i;
+}
+
+%token <i> number
+
+%%
+
+program         : expr
+                ;
+
+expr            : term '+' expr
+                | term
+                ;
+
+term            : factor '*' term
+                | factor
+                ;
+
+factor          : number
+                ;
+
+%%
+
+// Epilogue
+
+static enum yytokentype
+yylex(YYSTYPE *lval, YYLTYPE *yylloc)
+{
+    return 0;
+}
+
+static void yyerror(YYLTYPE *yylloc, const char *msg)
+{
+    (void) msg;
+}
+
+int main(int argc, char *argv[])
+{
+}

--- a/spec/lrama/output_spec.rb
+++ b/spec/lrama/output_spec.rb
@@ -1,0 +1,34 @@
+require "stringio"
+
+RSpec.describe Lrama::Output do
+  let(:output) {
+    Lrama::Output.new(
+      out: out,
+      output_file_path: "y.tab.c",
+      template_name: "bison/yacc.c",
+      grammar_file_path: "parse.tmp.y",
+      header_out: header_out,
+      header_file_path: "y.tab.h",
+      context: context,
+      grammar: grammar,      
+    )
+  }
+  let(:out) { StringIO.new }
+  let(:header_out) { StringIO.new }
+  let(:context) { double("context") }
+  let(:grammar) { double("grammar") }
+
+  describe "#parse_param" do
+    it "returns declaration of parse param without braces" do
+      allow(grammar).to receive(:parse_param).and_return("{struct parser_params *p}")
+      expect(output.parse_param).to eq("struct parser_params *p")
+    end
+  end
+
+  describe "#user_formals" do
+    it "returns declaration of parse param without braces with a leading comma" do
+      allow(grammar).to receive(:parse_param).and_return("{struct parser_params *p}")
+      expect(output.user_formals).to eq(", struct parser_params *p")
+    end
+  end
+end

--- a/spec/lrama/output_spec.rb
+++ b/spec/lrama/output_spec.rb
@@ -26,9 +26,18 @@ RSpec.describe Lrama::Output do
   end
 
   describe "#user_formals" do
-    it "returns declaration of parse param without braces with a leading comma" do
-      allow(grammar).to receive(:parse_param).and_return("{struct parser_params *p}")
-      expect(output.user_formals).to eq(", struct parser_params *p")
+    context "when parse_param exists" do
+      it "returns declaration of parse param without braces with a leading comma" do
+        allow(grammar).to receive(:parse_param).and_return("{struct parser_params *p}")
+        expect(output.user_formals).to eq(", struct parser_params *p")
+      end
+    end
+
+    context "when parse_param does not exist" do
+      it "returns blank" do
+        allow(grammar).to receive(:parse_param).and_return(nil)
+        expect(output.user_formals).to eq("")
+      end
     end
   end
 

--- a/spec/lrama/output_spec.rb
+++ b/spec/lrama/output_spec.rb
@@ -38,4 +38,11 @@ RSpec.describe Lrama::Output do
       expect(output.parse_param_name).to eq("p")
     end
   end
+
+  describe "#lex_param_name" do
+    it "returns name of lex param" do
+      allow(grammar).to receive(:lex_param).and_return("{struct parser_params *p}")
+      expect(output.lex_param_name).to eq("p")
+    end
+  end
 end

--- a/spec/lrama/output_spec.rb
+++ b/spec/lrama/output_spec.rb
@@ -31,4 +31,11 @@ RSpec.describe Lrama::Output do
       expect(output.user_formals).to eq(", struct parser_params *p")
     end
   end
+
+  describe "#parse_param_name" do
+    it "returns name of parse param" do
+      allow(grammar).to receive(:parse_param).and_return("{struct parser_params *p}")
+      expect(output.parse_param_name).to eq("p")
+    end
+  end
 end

--- a/spec/lrama/output_spec.rb
+++ b/spec/lrama/output_spec.rb
@@ -41,6 +41,22 @@ RSpec.describe Lrama::Output do
     end
   end
 
+  describe "#user_args" do
+    context "when parse_param exists" do
+      it "returns name of parse param without braces with a leading comma" do
+        allow(grammar).to receive(:parse_param).and_return("{struct parser_params *p}")
+        expect(output.user_args).to eq(", p")
+      end
+    end
+
+    context "when parse_param does not exist" do
+      it "returns blank" do
+        allow(grammar).to receive(:parse_param).and_return(nil)
+        expect(output.user_args).to eq("")
+      end
+    end
+  end
+
   describe "#parse_param_name" do
     it "returns name of parse param" do
       allow(grammar).to receive(:parse_param).and_return("{struct parser_params *p}")

--- a/template/bison/yacc.c
+++ b/template/bison/yacc.c
@@ -1417,7 +1417,7 @@ yybackup:
   if (yychar == YYEMPTY)
     {
       YYDPRINTF ((stderr, "Reading a token\n"));
-      yychar = yylex (&yylval, &yylloc, p);
+      yychar = yylex <%= output.yylex_formals %>;
     }
 
   if (yychar <= <%= output.eof_symbol.id.s_value %>)

--- a/template/bison/yacc.c
+++ b/template/bison/yacc.c
@@ -802,9 +802,7 @@ yy_symbol_value_print (FILE *yyo,
                        yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp<%= output.user_formals %>)
 {
   FILE *yyoutput = yyo;
-  YY_USE (yyoutput);
-  YY_USE (yylocationp);
-  YY_USE (p);
+<%= output.parse_param_use("yyoutput", "yylocationp") %>
   if (!yyvaluep)
     return;
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
@@ -1199,9 +1197,7 @@ static void
 yydestruct (const char *yymsg,
             yysymbol_kind_t yykind, YYSTYPE *yyvaluep, YYLTYPE *yylocationp<%= output.user_formals %>)
 {
-  YY_USE (yyvaluep);
-  YY_USE (yylocationp);
-  YY_USE (p);
+<%= output.parse_param_use("yyvaluep", "yylocationp") %>
   if (!yymsg)
     yymsg = "Deleting";
   YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);

--- a/template/bison/yacc.c
+++ b/template/bison/yacc.c
@@ -668,7 +668,7 @@ enum { YYENOMEM = -2 };
       }                                                           \
     else                                                          \
       {                                                           \
-        yyerror (&yylloc, p, YY_("syntax error: cannot back up")); \
+        yyerror (<%= output.yyerror_args %>, YY_("syntax error: cannot back up")); \
         YYERROR;                                                  \
       }                                                           \
   while (0)
@@ -1583,7 +1583,7 @@ yyerrlab:
                 yysyntax_error_status = YYENOMEM;
               }
           }
-        yyerror (&yylloc, p, yymsgp);
+        yyerror (<%= output.yyerror_args %>, yymsgp);
         if (yysyntax_error_status == YYENOMEM)
           YYNOMEM;
       }
@@ -1701,7 +1701,7 @@ yyabortlab:
 | yyexhaustedlab -- YYNOMEM (memory exhaustion) comes here.  |
 `-----------------------------------------------------------*/
 yyexhaustedlab:
-  yyerror (&yylloc, p, YY_("memory exhausted"));
+  yyerror (<%= output.yyerror_args %>, YY_("memory exhausted"));
   yyresult = 2;
   goto yyreturnlab;
 

--- a/template/bison/yacc.c
+++ b/template/bison/yacc.c
@@ -1301,10 +1301,7 @@ YYLTYPE yylloc = yyloc_default;
 
 
 <%# b4_user_initial_action -%>
-/* User initialization code.  */
-#line <%= output.grammar.initial_action.line %> "<%= output.grammar_file_path %>"
-<%= output.grammar.initial_action.translated_code %>
-
+<%= output.user_initial_action("/* User initialization code.  */") %>
 #line [@oline@] [@ofile@]
 
   yylsp[0] = yylloc;

--- a/template/bison/yacc.c
+++ b/template/bison/yacc.c
@@ -1604,7 +1604,7 @@ yyerrlab:
       else
         {
           yydestruct ("Error: discarding",
-                      yytoken, &yylval, &yylloc, p);
+                      yytoken, &yylval, &yylloc<%= output.user_args %>);
           yychar = YYEMPTY;
         }
     }
@@ -1660,7 +1660,7 @@ yyerrlab1:
 
       yyerror_range[1] = *yylsp;
       yydestruct ("Error: popping",
-                  YY_ACCESSING_SYMBOL (yystate), yyvsp, yylsp, p);
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp, yylsp<%= output.user_args %>);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
@@ -1716,7 +1716,7 @@ yyreturnlab:
          user semantic actions for why this is necessary.  */
       yytoken = YYTRANSLATE (yychar);
       yydestruct ("Cleanup: discarding lookahead",
-                  yytoken, &yylval, &yylloc, p);
+                  yytoken, &yylval, &yylloc<%= output.user_args %>);
     }
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYABORT or YYACCEPT.  */
@@ -1725,7 +1725,7 @@ yyreturnlab:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, yylsp, p);
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, yylsp<%= output.user_args %>);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow


### PR DESCRIPTION
Add a sample parser file ("sample/parse.y") because ruby/ruby parse.y requires preprocess.
Supporting "sample/parse.y", need to extract some template code into "lib/lrama/output.rb".