### PR TITLE
Backward compatibility

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['head', '3.2', '3.1', '3.0', '2.7']
+        ruby: ['head', '3.2', '3.1', '3.0', '2.7', '2.6', '2.5']
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1

--- a/lib/lrama/output.rb
+++ b/lib/lrama/output.rb
@@ -152,7 +152,7 @@ module Lrama
 
       <<-STR
         #{comment}
-        #line #{@grammar.initial_action.line} "#{@grammar_file_path}"
+#line #{@grammar.initial_action.line} "#{@grammar_file_path}"
         #{@grammar.initial_action.translated_code}
       STR
     end

--- a/lib/lrama/output.rb
+++ b/lib/lrama/output.rb
@@ -25,8 +25,18 @@ module Lrama
       @grammar = grammar
     end
 
+    if ERB.instance_method(:initialize).parameters.last.first == :key
+      def self.erb(input)
+        ERB.new(input, trim_mode: '-')
+      end
+    else
+      def self.erb(input)
+        ERB.new(input, nil, '-')
+      end
+    end
+
     def eval_template(file, path)
-      erb = ERB.new(File.read(file), trim_mode: '-')
+      erb = self.class.erb(File.read(file))
       erb.filename = file
       tmp = erb.result_with_hash(context: @context, output: self)
       replace_special_variables(tmp, path)

--- a/lib/lrama/output.rb
+++ b/lib/lrama/output.rb
@@ -25,19 +25,20 @@ module Lrama
       @grammar = grammar
     end
 
+    def eval_template(file, path)
+      erb = ERB.new(File.read(file), trim_mode: '-')
+      erb.filename = file
+      tmp = erb.result_with_hash(context: @context, output: self)
+      replace_special_variables(tmp, path)
+    end
+
     def render
       report_duration(:render) do
-        erb = ERB.new(File.read(template_file), trim_mode: '-')
-        erb.filename = template_file
-        tmp = erb.result_with_hash(context: @context, output: self)
-        tmp = replace_special_variables(tmp, @output_file_path)
+        tmp = eval_template(template_file, @output_file_path)
         @out << tmp
 
         if @header_file_path
-          erb = ERB.new(File.read(header_template_file), trim_mode: '-')
-          erb.filename = header_template_file
-          tmp = erb.result_with_hash(context: @context, output: self)
-          tmp = replace_special_variables(tmp, @header_file_path)
+          tmp = eval_template(header_template_file, @header_file_path)
 
           if @header_out
             @header_out << tmp

--- a/lib/lrama/states.rb
+++ b/lib/lrama/states.rb
@@ -776,7 +776,7 @@ module Lrama
         state.reduces.each do |reduce|
           next if reduce.look_ahead.nil?
 
-          intersection = a.intersection(reduce.look_ahead)
+          intersection = a & reduce.look_ahead
           a += reduce.look_ahead
 
           if !intersection.empty?


### PR DESCRIPTION
* [Use Array#& instead of Array#intersection](https://github.com/yui-knk/lrama/commit/2c8fd5dfe949462987069359d0f929d6e2a940bb)
* [Extract Lrama::Output#eval_template](https://github.com/yui-knk/lrama/commit/c681ad45ece215aa861e2dcafc569a8758f3ad42)
* [Support older ERb](https://github.com/yui-knk/lrama/commit/530294052642d78cfd1012de3d4c6ba82b15d6c8)
* [Remove indent at preprocessor directive for tool/ytab.sed](https://github.com/yui-knk/lrama/commit/8a621c8673393b065e34b55f48c83b5bb140d11a)